### PR TITLE
Add requirement: instructions to upload modpack as .zip

### DIFF
--- a/Proposal
+++ b/Proposal
@@ -215,6 +215,8 @@ At the core of the platform is the ability to analyze a user’s selected mod co
 - The system shall prevent submission if validation fails and display a clear, user-friendly error message.
 
 - The system shall allow the user to retry the upload process without restarting the application.
+
+- The UI shall provide clear instructions describing how users can compress their modpack into a .zip file before uploading.
 # 2.3.2 — Personas
 
 


### PR DESCRIPTION
This PR adds a requirement stating that the UI shall provide clear instructions on how users must compress their modpack into a .zip file before uploading.

This update addresses the feedback provided after the previous merge of Section 2.3 Requirements.