### PR TITLE
Added Install Guidence Panel to the Missing Dependencies page

### DIFF
--- a/src/main/java/com/inso/MinecraftProject/MainController.java
+++ b/src/main/java/com/inso/MinecraftProject/MainController.java
@@ -1,9 +1,45 @@
 package com.inso.MinecraftProject;
 
+import com.inso.MinecraftProject.view.MissingDependencyItem;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.List;
 @Controller
 
 public class MainController {
-   
+   @GetMapping("/missing-dependencies")
+    public String missingDependencies(Model model) {
+        List<MissingDependencyItem> missingDependencies = List.of(
+                new MissingDependencyItem(
+                        "Fabric API",
+                        "1.20.1",
+                        "Fabric",
+                        "/r?u=https://modrinth.com/mod/fabric-api",
+                        true
+                ),
+                new MissingDependencyItem(
+                        "Cloth Config",
+                        "1.20.1",
+                        "Fabric",
+                        "/r?u=https://modrinth.com/mod/cloth-config",
+                        true
+                ),
+                new MissingDependencyItem(
+                        "Unknown Dependency",
+                        "1.20.1",
+                        "Fabric",
+                        null,
+                        false
+                )
+        );
+
+        model.addAttribute("missingDependencies", missingDependencies);
+        model.addAttribute("analysisHasPartialResults", true);
+        model.addAttribute("loader", "Fabric");
+        model.addAttribute("minecraftVersion", "1.20.1");
+
+        return "missing-dependencies";
+    }
 }

--- a/src/main/java/com/inso/MinecraftProject/view/MissingDependencyItem.java
+++ b/src/main/java/com/inso/MinecraftProject/view/MissingDependencyItem.java
@@ -1,0 +1,10 @@
+package com.inso.MinecraftProject.view;
+
+public record MissingDependencyItem(
+        String name,
+        String version,
+        String loader,
+        String downloadUrl,
+        boolean resolved
+) {
+}

--- a/src/main/resources/static/missing-dependencies.css
+++ b/src/main/resources/static/missing-dependencies.css
@@ -1,0 +1,171 @@
+@font-face {
+    font-family: 'Monocraft';
+    src: url('/fonts/Monocraft-Light.ttf') format('truetype');
+    font-weight: 300;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'Monocraft';
+    src: url('/fonts/Monocraft-SemiBold.ttf') format('truetype');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body#page-missing-dependencies {
+    font-family: 'Monocraft', sans-serif;
+    background: linear-gradient(180deg, #10151c 0%, #17212b 100%);
+    color: #f5f5f5;
+    min-height: 100vh;
+    padding: 40px 24px;
+}
+
+.page-container {
+    max-width: 1300px;
+    margin: 0 auto;
+}
+
+.page-header {
+    margin-bottom: 32px;
+}
+
+.page-header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 12px;
+}
+
+.page-header p {
+    font-size: 1rem;
+    color: #d6d6d6;
+    max-width: 850px;
+    line-height: 1.6;
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 24px;
+}
+
+.side-panels {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.card {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.card h2 {
+    font-size: 1.25rem;
+    margin-bottom: 16px;
+}
+
+.info-banner {
+    background: rgba(62, 190, 69, 0.15);
+    border: 1px solid rgba(62, 190, 69, 0.45);
+    color: #dff6e2;
+    padding: 14px 16px;
+    border-radius: 12px;
+    margin-bottom: 20px;
+    line-height: 1.5;
+}
+
+.dependency-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.dependency-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 12px;
+    padding: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dependency-main h3 {
+    font-size: 1.1rem;
+    margin-bottom: 8px;
+}
+
+.dependency-main p {
+    color: #d2d2d2;
+    line-height: 1.5;
+}
+
+.download-btn {
+    display: inline-block;
+    text-decoration: none;
+    background: #3ebe45;
+    color: white;
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-weight: 600;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.download-btn:hover {
+    transform: translateY(-2px);
+    opacity: 0.95;
+}
+
+.unresolved {
+    text-align: right;
+}
+
+.unresolved-badge {
+    display: inline-block;
+    background: #b64646;
+    color: white;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    margin-bottom: 8px;
+}
+
+.warning-card ul,
+.card ul,
+.card ol {
+    padding-left: 20px;
+    line-height: 1.8;
+    color: #e2e2e2;
+}
+
+code {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 2px 6px;
+    border-radius: 6px;
+}
+
+@media (max-width: 960px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .dependency-item {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .unresolved {
+        text-align: left;
+    }
+}

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Missing Dependencies</title>
+    <link rel="stylesheet" href="/missing-dependencies.css" />
+</head>
+<body id="page-missing-dependencies">
+
+<div class="page-container">
+    <header class="page-header">
+        <h1>Missing Dependencies</h1>
+        <p>
+            Review the missing mods below, install the ones with available links,
+            and re-run analysis afterward.
+        </p>
+    </header>
+
+    <main class="content-grid">
+
+        <section class="card dependencies-card">
+            <h2>Detected Missing Dependencies</h2>
+
+            <div th:if="${analysisHasPartialResults}" class="info-banner">
+                Some dependencies were resolved, but others could not be matched automatically.
+                You can still install the resolved ones first and retry analysis.
+            </div>
+
+            <div class="dependency-list">
+                <div class="dependency-item" th:each="dependency : ${missingDependencies}">
+                    <div class="dependency-main">
+                        <h3 th:text="${dependency.name}">Dependency Name</h3>
+                        <p>
+                            Version:
+                            <span th:text="${dependency.version}">1.20.1</span>
+                            |
+                            Loader:
+                            <span th:text="${dependency.loader}">Fabric</span>
+                        </p>
+                    </div>
+
+                    <div class="dependency-actions" th:if="${dependency.resolved}">
+                        <a class="download-btn"
+                           th:href="${dependency.downloadUrl}"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                            Open Download Link
+                        </a>
+                    </div>
+
+                    <div class="dependency-actions unresolved" th:if="${!dependency.resolved}">
+                        <span class="unresolved-badge">Unresolved</span>
+                        <p>No safe download link could be resolved for this dependency.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <aside class="side-panels">
+
+            <section class="card">
+                <h2>How to install</h2>
+                <ol>
+                    <li>Open the dependency link for each missing mod.</li>
+                    <li>Download the file that matches your Minecraft version.</li>
+                    <li>Make sure the mod also matches your loader (<span th:text="${loader}">Fabric</span>).</li>
+                    <li>Place the downloaded <code>.jar</code> file into your modpack’s <code>mods</code> folder.</li>
+                    <li>After installing the missing mods, re-run analysis.</li>
+                </ol>
+            </section>
+
+            <section class="card warning-card">
+                <h2>Warnings</h2>
+                <ul>
+                    <li>Do not install a Forge mod in a Fabric modpack.</li>
+                    <li>Do not install a mod built for a different Minecraft version.</li>
+                    <li>If multiple files are listed, choose the one matching your current setup.</li>
+                </ul>
+            </section>
+
+            <section class="card">
+                <h2>What to do if unresolved</h2>
+                <ul>
+                    <li>Search for the dependency manually on Modrinth or CurseForge.</li>
+                    <li>Confirm the exact mod ID, Minecraft version, and loader.</li>
+                    <li>If the dependency still cannot be found, remove the parent mod or replace it with a compatible alternative.</li>
+                    <li>After making changes, re-run analysis to verify the dependency graph again.</li>
+                </ul>
+            </section>
+
+        </aside>
+    </main>
+</div>
+
+</body>
+</html>

--- a/src/test/java/com/inso/MinecraftProject/MainControllerTest.java
+++ b/src/test/java/com/inso/MinecraftProject/MainControllerTest.java
@@ -1,0 +1,26 @@
+package com.inso.MinecraftProject;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void missingDependenciesPageLoads() throws Exception {
+        mvc.perform(get("/missing-dependencies"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("missing-dependencies"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("How to install")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("What to do if unresolved")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("re-run analysis")));
+    }
+}


### PR DESCRIPTION
The Install Guidence Panel for the Missing Dependencies page is created, showing how to install the missing dependencies to the user, what does it need for it, and what to do in case of unresolved dependencies or unknown dependencies. 

IMPORTANT: This nees the issue https://github.com/uprm-inso4101-2025-2026-s2/semester-project-super_cool_minecraft_team/issues/256 to be fixed in order to run properly.