### PR TITLE
Add missing dependency response endpoint (#273)

### DIFF
--- a/src/main/java/com/inso/MinecraftProject/DependencyController.java
+++ b/src/main/java/com/inso/MinecraftProject/DependencyController.java
@@ -1,0 +1,22 @@
+package com.inso.MinecraftProject;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+public class DependencyController {
+
+    @GetMapping("/api/dependencies/missing")
+    public Map<String, Object> getMissingDependencies() {
+
+        Map<String, Object> response = new HashMap<>();
+
+        response.put("missingDependencies", new String[]{"example-mod"});
+        response.put("resolvedDependencies", new String[]{"fabric-api"});
+
+        return response;
+    }
+}


### PR DESCRIPTION
Implemented a backend endpoint for missing dependency responses.

Changes:
- Added DependencyController
- Implemented GET /api/dependencies/missing endpoint
- Returns JSON with missingDependencies and resolvedDependencies

This prepares the backend for future dependency resolution logic.
