### PR TITLE
Added Dependency method usage instead of hard coded tests to dependency look up service and controller utilizing modrinthwraper functions

### DIFF
--- a/src/main/java/com/inso/MinecraftProject/service/DependencyController.java
+++ b/src/main/java/com/inso/MinecraftProject/service/DependencyController.java
@@ -21,7 +21,12 @@ public class DependencyController {
     }
 
     @GetMapping("/api/dependencies/missing")
-    public ResponseEntity<?> getMissingDependencies(@RequestParam(defaultValue = "ok") String mode) {
+    public ResponseEntity<?> getMissingDependencies(
+            @RequestParam String slug,
+            @RequestParam(required = false) String loader,
+            @RequestParam(required = false) String mcVersion,
+            @RequestParam(defaultValue = "ok") String mode) {
+
         if ("fail429".equalsIgnoreCase(mode)) {
             return ResponseEntity.status(429).body(Map.of("message", "Dependency lookup was rate limited."));
         }
@@ -34,12 +39,8 @@ public class DependencyController {
             return ResponseEntity.status(504).body(Map.of("message", "Dependency lookup timed out."));
         }
 
-        List<MissingDependencyDto> missingDependencies = buildMissingDependencies(mode);
+        List<MissingDependencyDto> missingDependencies = dependencyLookupService.fetchMissingDependencies(slug, loader, mcVersion);
         List<ResolvedDependencyDto> resolvedDependencies = dependencyLookupService.resolveDependencies(missingDependencies);
-
-        if ("partial".equalsIgnoreCase(mode) && resolvedDependencies.size() > 1) {
-            resolvedDependencies = resolvedDependencies.subList(0, 1);
-        }
 
         boolean hasPartialResults = !resolvedDependencies.isEmpty()
                 && resolvedDependencies.size() < missingDependencies.size();
@@ -51,23 +52,5 @@ public class DependencyController {
         );
 
         return ResponseEntity.ok(response);
-    }
-
-    private List<MissingDependencyDto> buildMissingDependencies(String mode) {
-        if ("empty".equalsIgnoreCase(mode)) {
-            return List.of();
-        }
-
-        if ("partial".equalsIgnoreCase(mode)) {
-            return List.of(
-                    new MissingDependencyDto("fabric-api", "Fabric API", "0.100.1", "Fabric", "1.20.1"),
-                    new MissingDependencyDto("cloth-config", "Cloth Config", "11.1.136", "Fabric", "1.20.1")
-            );
-        }
-
-        return List.of(
-                new MissingDependencyDto("fabric-api", "Fabric API", "0.100.1", "Fabric", "1.20.1"),
-                new MissingDependencyDto("modmenu", "Mod Menu", "10.0.0", "Fabric", "1.20.1")
-        );
     }
 }

--- a/src/main/java/com/inso/MinecraftProject/service/DependencyLookupService.java
+++ b/src/main/java/com/inso/MinecraftProject/service/DependencyLookupService.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -94,6 +96,33 @@ public class DependencyLookupService {
         } catch (RuntimeException ex) {
             return Optional.empty();
         }
+    }
+
+    public List<MissingDependencyDto> fetchMissingDependencies(String slug, String loader, String mcVersion) {
+        JsonNode deps = modrinthServiceWrapper.getProjectDependencies(slug);
+
+        // Deduplicate required deps by project_id
+        Map<String, String> seen = new LinkedHashMap<>();
+        for (JsonNode dep : deps) {
+            String type = dep.path("dependency_type").asText("");
+            if (!"required".equals(type)) continue;
+            String projectId = dep.path("project_id").asText("");
+            if (projectId.isBlank()) continue;
+            seen.putIfAbsent(projectId, dep.path("version_id").asText(null));
+        }
+
+        List<MissingDependencyDto> result = new ArrayList<>();
+        for (Map.Entry<String, String> entry : seen.entrySet()) {
+            String projectId = entry.getKey();
+            String versionId = entry.getValue();
+            String name = projectId;
+            try {
+                JsonNode project = modrinthServiceWrapper.getProjectById(projectId);
+                name = project.path("title").asText(projectId);
+            } catch (RuntimeException ignored) {}
+            result.add(new MissingDependencyDto(projectId, name, versionId, loader, mcVersion));
+        }
+        return result;
     }
 
     private String buildCacheKey(MissingDependencyDto dependency) {


### PR DESCRIPTION
Remove hard coded dependency tests from Dependencylookup service using the modrinth wrapper functions and implemented them into the dependency controller. Since look up and versioning was already handled by another developer.

Please verify the changes and give feedback.