### PR TITLE
Assets path for missing dependencies page fixed

### DIFF
--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Missing Dependencies</title>
-    <link rel="stylesheet" href="../static/CSS_Files/missing-dependencies.css" />
+    <link rel="stylesheet" href="/CSS_Files/missing-dependencies.css" />
     <link rel="icon" type="image/x-icon" href="/images/logos/Header Icon- Cuadrado.ico">
 </head>
 <body id="page-missing-dependencies">
@@ -80,7 +80,7 @@
         </aside>
     </main>
 </div>
-<script src="../static/MissingDependencies/frontend-missing-dependencies.js"></script>
+<script type="module" src="/MissingDependencies/frontend-missing-dependencies.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The references to the paths assests for the missing dependencies page have been corrected. 