### PR TITLE
525 task add navigation button from missing dependencies page to upload page   team b frontend

### DIFF
--- a/src/main/resources/static/CSS_Files/missing-dependencies.css
+++ b/src/main/resources/static/CSS_Files/missing-dependencies.css
@@ -37,6 +37,36 @@ body#page-missing-dependencies {
     margin-bottom: 32px;
 }
 
+.header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.header-top h1 {
+    margin-bottom: 0;
+}
+
+.btn-primary {
+    display: inline-block;
+    background: #3ebe45;
+    color: white;
+    padding: 12px 20px;
+    border-radius: 10px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+    font-size: 0.95rem;
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    opacity: 0.95;
+}
+
 .page-header h1 {
     font-size: 2.5rem;
     margin-bottom: 12px;
@@ -200,5 +230,14 @@ code {
 
     .status-message {
         text-align: left;
+    }
+
+    .header-top {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .btn-primary {
+        align-self: flex-start;
     }
 }

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -4,14 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Missing Dependencies</title>
-    <link rel="stylesheet" href="../static/CSS_Files/missing-dependencies.css" />
+    <link rel="stylesheet" href="/CSS_Files/global.css" />
+    <link rel="stylesheet" href="/CSS_Files/missing-dependencies.css" />
     <link rel="icon" type="image/x-icon" href="/images/logos/Header Icon- Cuadrado.ico">
 </head>
 <body id="page-missing-dependencies">
 
 <div class="page-container">
     <header class="page-header">
-        <h1>Missing Dependencies</h1>
+        <div class="header-top">
+            <h1>Missing Dependencies</h1>
+            <a href="/upload" class="btn-primary">Upload Another Modpack</a>
+        </div>
         <p>
             Review the missing mods below, install the ones with available links,
             and re-run analysis afterward.
@@ -80,7 +84,7 @@
         </aside>
     </main>
 </div>
-<script src="../static/MissingDependencies/frontend-missing-dependencies.js"></script>
+<script src="/MissingDependencies/frontend-missing-dependencies.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The Missing Dependencies page was not rendering correctly due to incorrect relative paths 
for CSS and JS files. Fixed by changing to absolute paths pointing to /static/. Also added 
an "Upload Another Modpack" button in the header that links to the /upload route, allowing 
users to test another modpack after reviewing results.