### PR TITLE
Add back navigation button to graph visualizer

### DIFF
--- a/src/main/resources/static/CSS_Files/missing-dependencies.css
+++ b/src/main/resources/static/CSS_Files/missing-dependencies.css
@@ -202,3 +202,21 @@ code {
         text-align: left;
     }
 }
+
+
+.back-to-graph-button {
+    display: inline-block;
+    margin-top: 16px;
+    padding: 12px 18px;
+    background: #3ebe45;
+    color: white;
+    text-decoration: none;
+    border-radius: 10px;
+    font-weight: 600;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.back-to-graph-button:hover {
+    transform: translateY(-2px);
+    opacity: 0.95;
+}

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -15,6 +15,10 @@
             Review the missing mods below, install the ones with available links,
             and re-run analysis afterward.
         </p>
+
+        <a href="/graph" class="back-to-graph-button">
+            Back to Graph Visualizer
+        </a>
     </header>
 
     <main class="content-grid">


### PR DESCRIPTION
Added a navigation button in the Missing Dependencies page that redirects users back to the Graph Visualizer page (`/graph`).

Issue #513