### PR TITLE
Issue #527 Adding cache expiration to the dependency lookup service

### DIFF
--- a/src/main/java/com/inso/MinecraftProject/MinecraftProjectApplication.java
+++ b/src/main/java/com/inso/MinecraftProject/MinecraftProjectApplication.java
@@ -2,8 +2,10 @@ package com.inso.MinecraftProject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MinecraftProjectApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/inso/MinecraftProject/service/DependencyLookupCache.java
+++ b/src/main/java/com/inso/MinecraftProject/service/DependencyLookupCache.java
@@ -39,6 +39,10 @@ public class DependencyLookupCache<T> {
         cache.put(key, new CacheEntry<>(value, expiresAt));
     }
 
+    public void evictExpired(){
+        long now = System.currentTimeMillis();
+        cache.entrySet().removeIf(entry -> now > entry.getValue().expiresAt);
+    }
     private static class CacheEntry<T> {
         T value;
         long expiresAt;

--- a/src/main/java/com/inso/MinecraftProject/service/DependencyLookupService.java
+++ b/src/main/java/com/inso/MinecraftProject/service/DependencyLookupService.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.inso.MinecraftProject.dto.MissingDependencyDto;
 import com.inso.MinecraftProject.dto.ResolvedDependencyDto;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
@@ -21,9 +25,13 @@ public class DependencyLookupService {
     private final DependencyLookupCache<Optional<ResolvedDependencyDto>> cache;
     private final ModrinthServiceWrapper modrinthServiceWrapper;
 
-    public DependencyLookupService(ModrinthServiceWrapper modrinthServiceWrapper) {
-        this.cache = new DependencyLookupCache<>();
+    public DependencyLookupService(
+            ModrinthServiceWrapper modrinthServiceWrapper,
+            @Value("${cache.dependency.ttl-minutes:10}")long ttlMinutes) {
+        this.cache = new DependencyLookupCache<>(Duration.ofMinutes(ttlMinutes));
         this.modrinthServiceWrapper = modrinthServiceWrapper;
+            
+
     }
 
     public List<ResolvedDependencyDto> resolveDependencies(List<MissingDependencyDto> dependencies) {
@@ -247,5 +255,10 @@ public class DependencyLookupService {
 
     private String defaultString(String value) {
         return value == null ? "" : value;
+    }
+
+    @Scheduled(fixedRateString = "${cache.dependency.cleanup-interval-ms:60000}")
+    public void evictExpiredCacheEntries() {
+        cache.evictExpired();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=MinecraftProject
+cache.dependency.ttl-minutes=10
+cache.dependency.cleanup-interval-ms = 60000


### PR DESCRIPTION
Added configurable TTL support to DependencyLookupCache, wired via @Value 
from application.properties. Added a @Scheduled task to proactively evict 
expired entries every 60 seconds, preventing stale Modrinth data from being 
served. Enabled scheduling globally via @EnableScheduling on the main application class.