### PR TITLE
Coding sliding left control panel animation

### DIFF
--- a/src/main/java/com/inso/MinecraftProject/controller/DependencyController.java
+++ b/src/main/java/com/inso/MinecraftProject/controller/DependencyController.java
@@ -17,7 +17,7 @@ import com.inso.MinecraftProject.dto.MissingDependencyDto;
 import com.inso.MinecraftProject.dto.ResolvedDependencyDto;
 import com.inso.MinecraftProject.dto.ValidationResponse;
 import com.inso.MinecraftProject.entity.Mod;
-import com.inso.MinecraftProject.repository.ModRepository;
+import com.inso.MinecraftProject.service.ModRepository;
 import com.inso.MinecraftProject.service.DependencyResolverService;
 
 @RestController

--- a/src/main/resources/static/CSS_Files/graph_base.css
+++ b/src/main/resources/static/CSS_Files/graph_base.css
@@ -1094,17 +1094,20 @@ svg:active {
     transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
-.dashboard-container.sidebar-collapsed .sidebar {
-    transform: translateX(-100%);
-    opacity: 0;
-    pointer-events: none;
+.sidebar-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
 }
 
+.sidebar-title-row .group-label {
+    margin-bottom: 0;
+}
+
+
 .sidebar-toggle-btn {
-    position: absolute;
-    top: 16px;
-    left: 16px;
-    z-index: 50;
     width: 42px;
     height: 42px;
     border: none;
@@ -1113,8 +1116,15 @@ svg:active {
     color: white;
     font-size: 20px;
     cursor: pointer;
+    flex-shrink: 0;
 }
 
-.dashboard-container.sidebar-collapsed .sidebar-toggle-btn {
-    left: 16px;
+.sidebar-toggle-btn:hover {
+    background-color: #374151;
+}
+
+.dashboard-container.sidebar-collapsed .sidebar {
+    transform: translateX(-100%);
+    opacity: 0;
+    pointer-events: none;
 }

--- a/src/main/resources/static/CSS_Files/graph_base.css
+++ b/src/main/resources/static/CSS_Files/graph_base.css
@@ -1077,3 +1077,44 @@ svg:active {
                 r 0.3s ease, fill 0.3s ease, stroke 0.3s ease,
                 filter 0.3s ease;
 }
+
+
+/* Sliding left control panel animation */
+.dashboard-container {
+    position: relative;
+    transition: grid-template-columns 0.3s ease;
+}
+
+.dashboard-container.sidebar-collapsed {
+    grid-template-columns: 0 1fr;
+}
+
+.sidebar {
+    overflow: hidden;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.dashboard-container.sidebar-collapsed .sidebar {
+    transform: translateX(-100%);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.sidebar-toggle-btn {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    z-index: 50;
+    width: 42px;
+    height: 42px;
+    border: none;
+    border-radius: 8px;
+    background-color: #1f2937;
+    color: white;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+.dashboard-container.sidebar-collapsed .sidebar-toggle-btn {
+    left: 16px;
+}

--- a/src/main/resources/static/CSS_Files/graph_base.css
+++ b/src/main/resources/static/CSS_Files/graph_base.css
@@ -1128,3 +1128,27 @@ svg:active {
     opacity: 0;
     pointer-events: none;
 }
+/* reopen animation */
+.sidebar-reopen-btn {
+    position: absolute;
+    top: 22px;
+    left: 16px;
+    z-index: 60;
+    width: 42px;
+    height: 42px;
+    border: none;
+    border-radius: 8px;
+    background-color: #1f2937;
+    color: white;
+    font-size: 20px;
+    cursor: pointer;
+    display: none;
+}
+
+.sidebar-reopen-btn:hover {
+    background-color: #374151;
+}
+
+.dashboard-container.sidebar-collapsed .sidebar-reopen-btn {
+    display: block;
+}

--- a/src/main/resources/static/JS_Files/graph_visualization.js
+++ b/src/main/resources/static/JS_Files/graph_visualization.js
@@ -993,3 +993,18 @@ function exportGraphToPNG(svgSelector, fileName) {
 
     image.src = url;
 }
+/* SIDEBAR TOGGLE LOGIC */
+document.addEventListener("DOMContentLoaded", () => {
+    const dashboard = document.querySelector(".dashboard-container");
+    const toggleBtn = document.getElementById("sidebarToggleBtn");
+
+    if (!dashboard || !toggleBtn) return;
+
+    toggleBtn.addEventListener("click", () => {
+        dashboard.classList.toggle("sidebar-collapsed");
+
+        setTimeout(() => {
+            window.dispatchEvent(new Event("resize"));
+        }, 300);
+    });
+});

--- a/src/main/resources/static/JS_Files/graph_visualization.js
+++ b/src/main/resources/static/JS_Files/graph_visualization.js
@@ -996,15 +996,28 @@ function exportGraphToPNG(svgSelector, fileName) {
 /* SIDEBAR TOGGLE LOGIC */
 document.addEventListener("DOMContentLoaded", () => {
     const dashboard = document.querySelector(".dashboard-container");
-    const toggleBtn = document.getElementById("sidebarToggleBtn");
+    const closeBtn = document.getElementById("sidebarToggleBtn");
+    const reopenBtn = document.getElementById("sidebarReopenBtn");
 
-    if (!dashboard || !toggleBtn) return;
+    if (!dashboard) return;
 
-    toggleBtn.addEventListener("click", () => {
-        dashboard.classList.toggle("sidebar-collapsed");
-
+    const resizeGraphAfterAnimation = () => {
         setTimeout(() => {
             window.dispatchEvent(new Event("resize"));
         }, 300);
-    });
+    };
+
+    if (closeBtn) {
+        closeBtn.addEventListener("click", () => {
+            dashboard.classList.add("sidebar-collapsed");
+            resizeGraphAfterAnimation();
+        });
+    }
+
+    if (reopenBtn) {
+        reopenBtn.addEventListener("click", () => {
+            dashboard.classList.remove("sidebar-collapsed");
+            resizeGraphAfterAnimation();
+        });
+    }
 });

--- a/src/main/resources/templates/graph_visualization.html
+++ b/src/main/resources/templates/graph_visualization.html
@@ -39,6 +39,9 @@
     </header>
 
         <main class="dashboard-container">
+            <button id="sidebarReopenBtn" class="sidebar-reopen-btn" aria-label="Reopen sidebar">
+                ☰
+            </button>
             <aside class="sidebar">
                 <section class="sidebar-group">
                 <div class="sidebar-title-row">

--- a/src/main/resources/templates/graph_visualization.html
+++ b/src/main/resources/templates/graph_visualization.html
@@ -19,7 +19,7 @@
     <th:block th:if="${@environment.acceptsProfiles('dev')}">
         <script th:inline="javascript">
             // The available test modes are 'cycle', 'simple', and 'medium'
-             window.TEST_MODE = 'medium';
+            window.TEST_MODE = 'medium';
         </script>
     </th:block>
     <script th:src="@{/JS_Files/test_graph_data.js}"></script>
@@ -39,6 +39,9 @@
     </header>
 
     <main class="dashboard-container">
+        <button id="sidebarToggleBtn" class="sidebar-toggle-btn" aria-label="Toggle sidebar">
+            ☰
+        </button>
         <aside class="sidebar">
             <section class="sidebar-group">
                 <h3 class="group-label">MODPACK SELECTION</h3>

--- a/src/main/resources/templates/graph_visualization.html
+++ b/src/main/resources/templates/graph_visualization.html
@@ -38,13 +38,16 @@
         </div>
     </header>
 
-    <main class="dashboard-container">
-        <button id="sidebarToggleBtn" class="sidebar-toggle-btn" aria-label="Toggle sidebar">
-            ☰
-        </button>
-        <aside class="sidebar">
-            <section class="sidebar-group">
-                <h3 class="group-label">MODPACK SELECTION</h3>
+        <main class="dashboard-container">
+            <aside class="sidebar">
+                <section class="sidebar-group">
+                <div class="sidebar-title-row">
+                    <h3 class="group-label">MODPACK SELECTION</h3>
+
+                    <button id="sidebarToggleBtn" class="sidebar-toggle-btn" aria-label="Toggle sidebar">
+                        ☰
+                    </button>
+                </div>
                 <div class="folder-display">
                     <code>/home/user/Projects/ModpackG</code>
                 </div>


### PR DESCRIPTION
Issue #502 

Implemented a collapsible sliding left control panel for the graph visualization page
- Added sidebar toggle button next to Modpack Selection.
- Added visible reopen button when sidebar is hidden.
- Added smooth CSS transition for the sliding panel.
- Expanded graph workspace when sidebar is hidden.
- Triggered graph resize after sidebar animation.

Waiting for @nu-hazd, @harryto1 and @KarilysMuniz approval