### PR TITLE
Add search filter functionality for missing dependencies

### DIFF
--- a/src/main/resources/static/CSS_Files/missing-dependencies.css
+++ b/src/main/resources/static/CSS_Files/missing-dependencies.css
@@ -259,3 +259,25 @@ code {
     transform: translateY(-2px);
     opacity: 0.95;
 }
+
+
+.dependency-search {
+    width: 100%;
+    padding: 14px 16px;
+    margin-bottom: 20px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+    color: white;
+    font-family: 'Monocraft', sans-serif;
+    font-size: 0.95rem;
+}
+
+.dependency-search::placeholder {
+    color: #cfcfcf;
+}
+
+.dependency-search:focus {
+    outline: none;
+    border-color: #3ebe45;
+}

--- a/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
+++ b/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
@@ -56,6 +56,7 @@ async function missingDependenciesPage() {
             
             dependencyList.appendChild(createDependencyCard(dependencyObj, resolvedDependency));
         }
+        setupDependencySearch();
     } catch (error) {
         errorState.textContent = error.message || "Unable to load missing dependencies.";
         errorState.hidden = false;
@@ -111,6 +112,30 @@ function createDependencyCard(dependency, resolvedDependency) {
     dependencyCard.appendChild(dependencyMain);
     dependencyCard.appendChild(dependencyActions);
     return dependencyCard;
+}
+
+function setupDependencySearch() {
+    const searchInput = document.getElementById("dependency-search");
+    const dependencyList = document.getElementById("dependency-list");
+
+    if (!searchInput || !dependencyList) {
+        return;
+    }
+
+    searchInput.addEventListener("input", () => {
+        const searchValue = searchInput.value.toLowerCase();
+        const dependencyCards = dependencyList.querySelectorAll(".dependency-item");
+
+        dependencyCards.forEach((card) => {
+            const dependencyText = card.textContent.toLowerCase();
+
+            if (dependencyText.includes(searchValue)) {
+                card.style.display = "flex";
+            } else {
+                card.style.display = "none";
+            }
+        });
+    });
 }
 
 

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -30,6 +30,12 @@
 
         <section class="card dependencies-card">
             <h2>Detected Missing Dependencies</h2>
+            <input
+                type="text"
+                id="dependency-search"
+                class="dependency-search"
+                placeholder="Search dependencies..."
+            />
 
            <div id="partial-results-banner" class="info-banner" hidden>
             Some dependencies were resolved, but others could not be matched automatically.


### PR DESCRIPTION
Added a search/filter bar to the Missing Dependencies page with real-time dependency filtering. Added styling for the search input and verified that matching dependency cards remain visible while non-matching cards are hidden during typing.

Closes #575 