### PR TITLE
Added background theme to graph visualization page

### DIFF
--- a/src/main/resources/static/CSS_Files/graph_base.css
+++ b/src/main/resources/static/CSS_Files/graph_base.css
@@ -1229,3 +1229,17 @@ body.light-theme {
     --line: rgba(0, 0, 0, 0.16);
     --line-soft: rgba(0, 0, 0, 0.08);
 }
+body#page-graph {
+  background-image: url("/images/Background1.png");
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+}
+
+.dashboard-container,
+.graph-workspace,
+#dependency-graph-canvas,
+svg {
+  background: transparent;
+}

--- a/src/main/resources/templates/graph_visualization.html
+++ b/src/main/resources/templates/graph_visualization.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Minecraft DT - Dependency Visualizer</title>
+    <link rel="stylesheet" href="/CSS_Files/global.css">
     <link rel="stylesheet" href="/CSS_Files/graph_base.css">
     
     <!-- D3 Library -->
@@ -30,7 +31,7 @@
 </head>
 
 
-<body>
+<body class="site-background" id="page-graph">
 
    <header class="mc-navbar">
     <div class="header-content">


### PR DESCRIPTION
Closes #600
Parent issue: #509

Added a background image to the graph visualization page and ensured 
all overlapping containers have transparent backgrounds so the image shows through correctly. 