### PR TITLE
Add dependency summary section

### DIFF
--- a/src/main/resources/static/CSS_Files/missing-dependencies.css
+++ b/src/main/resources/static/CSS_Files/missing-dependencies.css
@@ -346,3 +346,35 @@ code {
         word-break: break-word;
     }
 }
+
+
+
+.dependency-summary {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.summary-item {
+    flex: 1;
+    min-width: 120px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    padding: 14px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.summary-label {
+    color: #cfcfcf;
+    font-size: 0.9rem;
+}
+
+.summary-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #3ebe45;
+}

--- a/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
+++ b/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
@@ -56,6 +56,30 @@ async function missingDependenciesPage() {
             
             dependencyList.appendChild(createDependencyCard(dependencyObj, resolvedDependency));
         }
+
+
+        const totalDependencies = missingDependencies.length;
+        const resolvedDependencies = resolvedById.size;
+        const unresolvedDependencies =
+            totalDependencies - resolvedDependencies;
+
+        const dependencySummary =
+            document.getElementById("dependency-summary");
+
+        document.getElementById("summary-total").textContent =
+            totalDependencies;
+
+        document.getElementById("summary-resolved").textContent =
+            resolvedDependencies;
+
+        document.getElementById("summary-unresolved").textContent =
+            unresolvedDependencies;
+
+        dependencySummary.hidden = false;
+
+
+
+        
         setupDependencySearch();
     } catch (error) {
         errorState.textContent = error.message || "Unable to load missing dependencies.";

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -37,6 +37,21 @@
                 placeholder="Search dependencies..."
             />
 
+            <div id="dependency-summary" class="dependency-summary" hidden>
+                <div class="summary-item">
+                    <span class="summary-label">Total</span>
+                    <span id="summary-total" class="summary-value">0</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Resolved</span>
+                    <span id="summary-resolved" class="summary-value">0</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Unresolved</span>
+                    <span id="summary-unresolved" class="summary-value">0</span>
+                </div>
+            </div>
+
            <div id="partial-results-banner" class="info-banner" hidden>
             Some dependencies were resolved, but others could not be matched automatically.
             You can still install the resolved ones first and retry analysis.


### PR DESCRIPTION
Added a dependency summary section to the Missing Dependencies page, displaying total, resolved, and unresolved dependency counts. The summary updates dynamically from analysis results and matches the existing page styling and layout.

Closes issue #645 