### PR TITLE
Add clear search button for dependency filter

### DIFF
--- a/src/main/resources/static/CSS_Files/missing-dependencies.css
+++ b/src/main/resources/static/CSS_Files/missing-dependencies.css
@@ -378,3 +378,32 @@ code {
     font-weight: 600;
     color: #3ebe45;
 }
+
+
+
+.search-container {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.search-container .dependency-search {
+    margin-bottom: 0;
+    flex: 1;
+}
+
+.clear-search-button {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: white;
+    border-radius: 10px;
+    padding: 0 16px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.clear-search-button:hover {
+    background: rgba(255, 255, 255, 0.14);
+    transform: translateY(-1px);
+}

--- a/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
+++ b/src/main/resources/static/MissingDependencies/frontend-missing-dependencies.js
@@ -140,6 +140,7 @@ function createDependencyCard(dependency, resolvedDependency) {
 
 function setupDependencySearch() {
     const searchInput = document.getElementById("dependency-search");
+    const clearButton = document.getElementById("clear-search-button");
     const dependencyList = document.getElementById("dependency-list");
 
     if (!searchInput || !dependencyList) {
@@ -159,6 +160,19 @@ function setupDependencySearch() {
                 card.style.display = "none";
             }
         });
+    });
+
+    clearButton.addEventListener("click", () => {
+        searchInput.value = "";
+
+        const dependencyCards =
+            dependencyList.querySelectorAll(".dependency-item");
+
+        dependencyCards.forEach((card) => {
+            card.style.display = "flex";
+        });
+
+        searchInput.focus();
     });
 }
 

--- a/src/main/resources/templates/missing-dependencies.html
+++ b/src/main/resources/templates/missing-dependencies.html
@@ -30,12 +30,21 @@
 
         <section class="card dependencies-card">
             <h2>Detected Missing Dependencies</h2>
-            <input
-                type="text"
-                id="dependency-search"
-                class="dependency-search"
-                placeholder="Search dependencies..."
-            />
+            <div class="search-container">
+                <input
+                    type="text"
+                    id="dependency-search"
+                    class="dependency-search"
+                    placeholder="Search dependencies..."
+                />
+
+                <button
+                    id="clear-search-button"
+                    class="clear-search-button"
+                    type="button">
+                    ✕
+                </button>
+            </div>
 
             <div id="dependency-summary" class="dependency-summary" hidden>
                 <div class="summary-item">


### PR DESCRIPTION
Added a clear search button to the Missing Dependencies search bar. The button clears the search input, restores all dependency cards, and works with the existing dependency filtering functionality while maintaining the current page styling and layout.

Closes #659 